### PR TITLE
add INTEL_AUDIO_HAL selection flag.

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+ifeq ($(INTEL_AUDIO_HAL),audio)
+
 LOCAL_PATH := $(call my-dir)
 
 include $(CLEAR_VARS)
@@ -43,3 +45,5 @@ LOCAL_MODULE_RELATIVE_PATH := hw
 LOCAL_MODULE_TAGS := optional
 
 include $(BUILD_SHARED_LIBRARY)
+
+endif # INTEL_AUDIO_HAL


### PR DESCRIPTION
@plbossart, @kalyankondapally please review this update for Audio selection.

In order to be able to switch between baseline and Paramerter
Framework Audio HAL the flag INTEL_AUDIO_HAL needs to be propagated to
Baseline HAL.

Jira: None

Test: Build on latest manifest of the 2 different Audio stacks.

Signed-off-by: Sebastien Guiriec <sebastien.guiriec@intel.com>